### PR TITLE
Added CBV and NZA codes to procedure profile and query

### DIFF
--- a/input/pagecontent/data-exchange.md
+++ b/input/pagecontent/data-exchange.md
@@ -36,9 +36,9 @@ This approach is useful for applications that need to query specific parts of a 
 The below listed search requests show how all the ACP agreements, procedural information and relevant clinical context can be retrieved. Information on individuals involved in the ACP process are referenced from these resources and can be retrieved using the `_include` statement as defined below, or by resolving the references. Standard FHIR rules apply on the search syntax.
 
 ```
-1a GET [base]/Procedure?patient=Patient/[id]&code=http://snomed.info/sct|713603004&_include=Procedure:encounter
+1a GET [base]/Procedure?patient=Patient/[id]&code=http://snomed.info/sct|713603004,urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099&_include=Procedure:encounter
 
-1b GET [base]/Encounter?patient=Patient/[id]&reason=http://snomed.info/sct|713603004
+1b GET [base]/Encounter?patient=Patient/[id]&reason=http://snomed.info/sct|713603004,urn:oid:2.16.840.1.113883.2.4.3.120.5.3|411600B,urn:oid:2.16.840.1.113883.2.4.3.27.15.5|190099
 
 2 GET [base]/Consent?patient=Patient/[id]&category=http://snomed.info/sct|11291000146105&_include=Consent:actor
 

--- a/input/resources/StructureDefinition-ACP-Procedure.json
+++ b/input/resources/StructureDefinition-ACP-Procedure.json
@@ -63,7 +63,21 @@
       {
         "id": "Procedure.code.coding",
         "path": "Procedure.code.coding",
-        "min": 1
+        "min": 1,
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "system"
+            },
+            {
+              "type": "value",
+              "path": "code"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
       },
       {
         "id": "Procedure.code.coding:VerrichtingTypeCodelijst",

--- a/input/resources/StructureDefinition-ACP-Procedure.json
+++ b/input/resources/StructureDefinition-ACP-Procedure.json
@@ -83,31 +83,55 @@
         "id": "Procedure.code.coding:VerrichtingTypeCodelijst",
         "path": "Procedure.code.coding",
         "sliceName": "VerrichtingTypeCodelijst",
-        "max": "1",
-        "patternCoding": {
-          "system": "http://snomed.info/sct",
-          "code": "713603004"
-        }
+        "max": "1"
       },
       {
-        "id": "Procedure.code.coding:CBV",
+        "id": "Procedure.code.coding:VerrichtingTypeCodelijst.system",
+        "path": "Procedure.code.coding.system",
+        "min": 1,
+        "fixedUri": "http://snomed.info/sct"
+      },
+      {
+        "id": "Procedure.code.coding:VerrichtingTypeCodelijst.code",
+        "path": "Procedure.code.coding.code",
+        "min": 1,
+        "fixedCode": "713603004"
+      },
+      {
+        "id": "Procedure.code.coding:DHD_CBV_Bestand",
         "path": "Procedure.code.coding",
         "sliceName": "DHD_CBV_Bestand",
-        "max": "1",
-        "patternCoding": {
-          "system": "urn:oid:2.16.840.1.113883.2.4.3.120.5.3",
-          "code": "411600B"
-        }
+        "max": "1"
       },
       {
-        "id": "Procedure.code.coding:NZA",
+        "id": "Procedure.code.coding:DHD_CBV_Bestand.system",
+        "path": "Procedure.code.coding.system",
+        "min": 1,
+        "fixedUri": "urn:oid:2.16.840.1.113883.2.4.3.120.5.3"
+      },
+      {
+        "id": "Procedure.code.coding:DHD_CBV_Bestand.code",
+        "path": "Procedure.code.coding.code",
+        "min": 1,
+        "fixedCode": "411600B"
+      },
+      {
+        "id": "Procedure.code.coding:NZA_Verrichtingen",
         "path": "Procedure.code.coding",
         "sliceName": "NZA_Verrichtingen",
-        "max": "1",
-        "patternCoding": {
-          "system": "urn:oid:2.16.840.1.113883.2.4.3.27.15.5",
-          "code": "190099"
-        }
+        "max": "1"
+      },
+      {
+        "id": "Procedure.code.coding:NZA_Verrichtingen.system",
+        "path": "Procedure.code.coding.system",
+        "min": 1,
+        "fixedUri": "urn:oid:2.16.840.1.113883.2.4.3.27.15.5"
+      },
+      {
+        "id": "Procedure.code.coding:NZA_Verrichtingen.code",
+        "path": "Procedure.code.coding.code",
+        "min": 1,
+        "fixedCode": "190099"
       },
       {
         "id": "Procedure.subject",

--- a/input/resources/StructureDefinition-ACP-Procedure.json
+++ b/input/resources/StructureDefinition-ACP-Procedure.json
@@ -72,7 +72,7 @@
         "max": "1",
         "patternCoding": {
           "system": "http://snomed.info/sct",
-          "code": "900000000000013009"
+          "code": "713603004"
         }
       },
       {

--- a/input/resources/StructureDefinition-ACP-Procedure.json
+++ b/input/resources/StructureDefinition-ACP-Procedure.json
@@ -78,7 +78,7 @@
       {
         "id": "Procedure.code.coding:CBV",
         "path": "Procedure.code.coding",
-        "sliceName": "DHD CBV bestand",
+        "sliceName": "DHD_CBV_Bestand",
         "max": "1",
         "patternCoding": {
           "system": "urn:oid:2.16.840.1.113883.2.4.3.120.5.3",
@@ -88,7 +88,7 @@
       {
         "id": "Procedure.code.coding:NZA",
         "path": "Procedure.code.coding",
-        "sliceName": "NZA Verrichtingen",
+        "sliceName": "NZA_Verrichtingen",
         "max": "1",
         "patternCoding": {
           "system": "urn:oid:2.16.840.1.113883.2.4.3.27.15.5",

--- a/input/resources/StructureDefinition-ACP-Procedure.json
+++ b/input/resources/StructureDefinition-ACP-Procedure.json
@@ -52,14 +52,6 @@
         "id": "Procedure.code",
         "path": "Procedure.code",
         "min": 1,
-        "patternCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "713603004"
-            }
-          ]
-        },
         "mapping": [
           {
             "identity": "pall-izppz-zib2020v2026-02-24",
@@ -67,6 +59,41 @@
             "comment": "PZP gesprek (VerrichtingType)"
           }
         ]
+      },
+      {
+        "id": "Procedure.code.coding",
+        "path": "Procedure.code.coding",
+        "min": 1
+      },
+      {
+        "id": "Procedure.code.coding:VerrichtingTypeCodelijst",
+        "path": "Procedure.code.coding",
+        "sliceName": "VerrichtingTypeCodelijst",
+        "max": "1",
+        "patternCoding": {
+          "system": "http://snomed.info/sct",
+          "code": "900000000000013009"
+        }
+      },
+      {
+        "id": "Procedure.code.coding:CBV",
+        "path": "Procedure.code.coding",
+        "sliceName": "DHD CBV bestand",
+        "max": "1",
+        "patternCoding": {
+          "system": "urn:oid:2.16.840.1.113883.2.4.3.120.5.3",
+          "code": "411600B"
+        }
+      },
+      {
+        "id": "Procedure.code.coding:NZA",
+        "path": "Procedure.code.coding",
+        "sliceName": "NZA Verrichtingen",
+        "max": "1",
+        "patternCoding": {
+          "system": "urn:oid:2.16.840.1.113883.2.4.3.27.15.5",
+          "code": "190099"
+        }
       },
       {
         "id": "Procedure.subject",


### PR DESCRIPTION
To be able to use CBV and NZA codes as well we added two slices to procedure.code. This differs from the design in R4. In R4 we followed the design of the nl-core R4 profile with a subset of the already bound valueset. In the nl-core for STU3 the design of this element was a slice with a binding to the DHD verrichtingtype codelijst in Snomed. The solution in STU3 is thus instead of adding a subset of the valueset making two extra slices for the CBV and the NZA codes. 

fixes https://github.com/IKNL/PZP-FHIR-R4/issues/132