### PR TITLE
Update Firely.Terminal action version to v0.8.16

### DIFF
--- a/.github/workflows/stu3_firely_terminal.yaml
+++ b/.github/workflows/stu3_firely_terminal.yaml
@@ -38,7 +38,7 @@ jobs:
           java-version: '21'
         
       - name: Firely.Terminal (GitHub Actions)
-        uses: FirelyTeam/firely-terminal-pipeline@v0.8.1
+        uses: FirelyTeam/firely-terminal-pipeline@v0.8.16
         with:
           PATH_TO_CONFORMANCE_RESOURCES: input/resources
           PATH_TO_EXAMPLES: input/resources


### PR DESCRIPTION
Because of issues with the validation pipeline we updated the  version of firely-terminal-pipeline to v0.8.16